### PR TITLE
Fix nvm problem with same variable name

### DIFF
--- a/etc/profile.d/90-enable-wsl-ssh.sh
+++ b/etc/profile.d/90-enable-wsl-ssh.sh
@@ -6,7 +6,7 @@ fi
 ## NB: We can't find PREFIX easily in a profile.d script so we'll need to
 ## try to guess what it is by running down the existing path
 BINDIR=$(dirname `which wsl-enable-ssh-agent`)
-PREFIX=$(realpath "$BINDIR/..")
+PREFIXX=$(realpath "$BINDIR/..")
 
 ## Put our symlinked OpenSSH in front of the real one
-export PATH="$PREFIX/lib/wsl-ssh:$PATH"
+export PATH="$PREFIXX/lib/wsl-ssh:$PATH"

--- a/etc/profile.d/90-enable-wsl-ssh.sh
+++ b/etc/profile.d/90-enable-wsl-ssh.sh
@@ -5,8 +5,8 @@ fi
 
 ## NB: We can't find PREFIX easily in a profile.d script so we'll need to
 ## try to guess what it is by running down the existing path
-BINDIR=$(dirname `which wsl-enable-ssh-agent`)
-PREFIXX=$(realpath "$BINDIR/..")
+bindir=$(dirname `which wsl-enable-ssh-agent`)
+prefix=$(realpath "$bindir/..")
 
 ## Put our symlinked OpenSSH in front of the real one
-export PATH="$PREFIXX/lib/wsl-ssh:$PATH"
+export PATH="$prefix/lib/wsl-ssh:$PATH"


### PR DESCRIPTION
It seems that NVM is also using the `PREFIX` environment variable. So each time when starting WSL I get:

```
nvm is not compatible with the "PREFIX" environment variable: currently set to "/usr" 
Run `unset PREFIX` to unset it.
```

I could fix it in my setup as seen in this PR